### PR TITLE
lvm-factory-reset: Use proper partition label for sailfish partition

### DIFF
--- a/factory-reset-lvm
+++ b/factory-reset-lvm
@@ -70,9 +70,9 @@ RESERVE_KB=$(expr $2 \* 1024)
 
 echo "$NAME: Starting factory reset.." > /dev/kmsg
 
-PHYSDEV=$(find-mmc-bypartlabel "sailfishos")
+PHYSDEV=$(find-mmc-bypartlabel "sailfish")
 if test $? != "0"; then
-	echo "$NAME: Error: could not find sailfishos partition" > /dev/kmsg
+	echo "$NAME: Error: could not find sailfish partition" > /dev/kmsg
 	exit 1
 fi
 


### PR DESCRIPTION
The Sailfish OS partition label on Jolla Tablet has been changed to
follow the same naming as on Jolla Phone, which is "sailfish" instead
of "sailfishos". Adjust physical partition search accordingly.

[lvm-factory-reset] Use proper partition label for sailfish partition. Fixes JB#30029

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
