### PR TITLE
[factory-reset] Use rsync to preserve all attributes. Fixes JB#30178

### DIFF
--- a/factory-reset-lvm
+++ b/factory-reset-lvm
@@ -157,11 +157,11 @@ if ! test -f $SAILFISH_FIMAGE/sailfish_home.squashfs.img; then
 fi
 
 mount -t squashfs -o loop $SAILFISH_FIMAGE/sailfish_root.squashfs.img $TEMPMOUNT
-cp -a $TEMPMOUNT/* $MOUNT_POINT
+rsync -a -H -A -X $TEMPMOUNT/* $MOUNT_POINT
 sync
 umount $TEMPMOUNT
 mount -t squashfs -o loop $SAILFISH_FIMAGE/sailfish_home.squashfs.img $TEMPMOUNT
-cp -a $TEMPMOUNT/* $MOUNT_POINT/home
+rsync -a -H -A -X $TEMPMOUNT/* $MOUNT_POINT/home
 sync
 umount $TEMPMOUNT
 rmdir $TEMPMOUNT

--- a/rpm/initrd-helpers.spec
+++ b/rpm/initrd-helpers.spec
@@ -7,6 +7,7 @@ License:    GPLv2
 Source0:    %{name}-%{version}.tar.gz
 
 Requires:  btrfs-progs
+Requires:  rsync
 
 %description
 %{summary}


### PR DESCRIPTION
cp from busybox doesn't support copying extended attributes. Also
standalone cp from mer packages is still too old to support xattr.
Fixed by migrating to rsync with -a -X -A -H options to preserve
all file attributes.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
