### PR TITLE
Fix cases where the system might be on sda and fix some shellcheck warnings

### DIFF
--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -32,9 +32,9 @@ fi
 
 while [ ! -d /sys/class/block/mmcblk0p* ]; do
     echo "find-mmc-bypartlabel: Waiting for /sys/class/block/mmcblk0p*..." > /dev/kmsg
-    (( i++ ))
+    i=$(( ${i:-0} + 1 ))
     sleep 0.5
-    if [ $i == 10 ]; then
+    if [ $i = 10 ]; then
         echo "find-mmc-bypartlabel: Error: timeout waiting for /sys/class/block/mmcblk0p*" > /dev/kmsg
         exit 1
     fi

--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -30,7 +30,7 @@ if [ ! -d /sys/class/block ]; then
 	exit 1
 fi
 
-while [ ! -d /sys/class/block/mmcblk0p* ]; do
+while [ ! -d /sys/class/block/mmcblk0p* ] && [ ! -d /sys/class/block/sda ] ; do
     echo "find-mmc-bypartlabel: Waiting for /sys/class/block/mmcblk0p*..." > /dev/kmsg
     i=$(( ${i:-0} + 1 ))
     sleep 0.5
@@ -40,7 +40,7 @@ while [ ! -d /sys/class/block/mmcblk0p* ]; do
     fi
 done
 
-for mmc_sysfs in /sys/class/block/mmcblk0p*/*/; do
+for mmc_sysfs in /sys/class/block/mmcblk0p*/ /sys/class/block/sda*/; do
 	if grep -w PARTNAME="$1" "$mmc_sysfs"/uevent > /dev/null; then
 		FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
 		echo "/dev/$FIMAGE_DEV_NAME"

--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -20,12 +20,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Pass the partition label name as $1
-if test -z $1; then
+if [ -z "$1" ]; then
 	echo "$0: Error, no label name given!" > /dev/kmsg
 	exit 1
 fi
 
-if ! test -d /sys/class/block; then
+if [ ! -d /sys/class/block ]; then
 	echo "$0: Error, please mount sysfs" > /dev/kmsg
 	exit 1
 fi

--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -41,7 +41,7 @@ while [ ! -d /sys/class/block/mmcblk0p* ] && [ ! -d /sys/class/block/sda ] ; do
 done
 
 for mmc_sysfs in /sys/class/block/mmcblk0p*/ /sys/class/block/sda*/; do
-	if grep -w PARTNAME="$1" "$mmc_sysfs"/uevent > /dev/null; then
+	if grep -q -w PARTNAME="$1" "$mmc_sysfs"/uevent 2> /dev/null; then
 		FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
 		echo "/dev/$FIMAGE_DEV_NAME"
 		exit 0

--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -41,7 +41,7 @@ while [ ! -d /sys/class/block/mmcblk0p* ]; do
 done
 
 for mmc_sysfs in $(ls -d /sys/class/block/mmcblk0p*); do
-	if cat $mmc_sysfs/uevent | grep -w PARTNAME=$1 > /dev/null; then
+	if grep -w PARTNAME="$1" "$mmc_sysfs"/uevent > /dev/null; then
 		FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
 		echo "/dev/$FIMAGE_DEV_NAME"
 		exit 0

--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -40,7 +40,7 @@ while [ ! -d /sys/class/block/mmcblk0p* ]; do
     fi
 done
 
-for mmc_sysfs in $(ls -d /sys/class/block/mmcblk0p*); do
+for mmc_sysfs in /sys/class/block/mmcblk0p*/*/; do
 	if grep -w PARTNAME="$1" "$mmc_sysfs"/uevent > /dev/null; then
 		FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
 		echo "/dev/$FIMAGE_DEV_NAME"


### PR DESCRIPTION
- Use test/[] in consistent way.
- Fix warnings about using non POSIX features
- Use grep directly and quote.
- Loop by using globs instead of ls
- Test for cases where the disk is on sda
- Silence grep output with -q and ignore stderr