### PR TITLE
Fix for incorrect partition detection logic Contributes to JB#48714

### DIFF
--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -39,9 +39,7 @@ while [ ! -d /sys/class/block/mmcblk0p* ] && [ ! -d /sys/class/block/sda ] ; do
         exit 1
     fi
 done
-FIMAGE_DEV_NAME=""
-i=0
-while [ -z "$FIMAGE_DEV_NAME" ]; do
+while [ ${i:-0} -le 50 ] ; do
 	for mmc_sysfs in /sys/class/block/mmcblk0p*/ /sys/class/block/sda*/; do
 		if grep -q -w PARTNAME="$1" "$mmc_sysfs"/uevent 2> /dev/null; then
 			FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
@@ -51,10 +49,6 @@ while [ -z "$FIMAGE_DEV_NAME" ]; do
 	done
 	sleep 0.1
     	i=$(( ${i:-0} + 1 ))
-	if [ $i -eq 50 ]; then
-		echo "find-mmc-bypartlabel: Error: timeout waiting for partition $1" > /dev/kmsg
-		exit 1
-	fi
 done
 
 echo "$0: Error, could not find partition label \"$1\"" > /dev/kmsg

--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -34,17 +34,26 @@ while [ ! -d /sys/class/block/mmcblk0p* ] && [ ! -d /sys/class/block/sda ] ; do
     echo "find-mmc-bypartlabel: Waiting for /sys/class/block/mmcblk0p*..." > /dev/kmsg
     i=$(( ${i:-0} + 1 ))
     sleep 0.5
-    if [ $i = 10 ]; then
+    if [ $i -eq 10 ]; then
         echo "find-mmc-bypartlabel: Error: timeout waiting for /sys/class/block/mmcblk0p*" > /dev/kmsg
         exit 1
     fi
 done
-
-for mmc_sysfs in /sys/class/block/mmcblk0p*/ /sys/class/block/sda*/; do
-	if grep -q -w PARTNAME="$1" "$mmc_sysfs"/uevent 2> /dev/null; then
-		FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
-		echo "/dev/$FIMAGE_DEV_NAME"
-		exit 0
+FIMAGE_DEV_NAME=""
+i=0
+while [ -z "$FIMAGE_DEV_NAME" ]; do
+	for mmc_sysfs in /sys/class/block/mmcblk0p*/ /sys/class/block/sda*/; do
+		if grep -q -w PARTNAME="$1" "$mmc_sysfs"/uevent 2> /dev/null; then
+			FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
+			echo "/dev/$FIMAGE_DEV_NAME"
+			exit 0
+		fi
+	done
+	sleep 0.1
+    	i=$(( ${i:-0} + 1 ))
+	if [ $i -eq 50 ]; then
+		echo "find-mmc-bypartlabel: Error: timeout waiting for partition $1" > /dev/kmsg
+		exit 1
 	fi
 done
 


### PR DESCRIPTION
Original code of find-mmc-bypartlabel looks for any mmc partition
device appearance in sysfs and waits if there is none. Otherwise
it directly checks for label it is looking for and if not found
exits with error.

However on mmcs with large number of partitions (or slower ones)
partitions do not appear all at once, so it is possible that
1. There are mmc partitions in sysfs
2. There is no particular label partition yet
(because not all partitions are there yet).

The patch here handles this partcular case in pecular way
by waiting a bit and retrying 50 times (which makes worse case
till error to 5 seconds which should be enough for most cases,
but this might need to be increased in case of marginally slow
EMMC chips (or old heavily used EMMC chips).

Contributes to JB#48714