### PR TITLE
mount sysfs before flashing firmwares. Contributes to JB#49590

### DIFF
--- a/factory-reset-lvm
+++ b/factory-reset-lvm
@@ -56,10 +56,11 @@ flash_firmwares()
 	mount -t tmpfs tmpfs $1/tmp
 	mount -t devtmpfs devtmpfs $1/dev
 	mount -t proc proc $1/proc
+	mount -t sysfs sys $1/sys
 	flash_script > $1/tmp/flash-firmwares
 	chmod 755 $1/tmp/flash-firmwares
 	chroot $1 /tmp/flash-firmwares
-	umount $1/tmp $1/dev $1/proc
+	umount $1/tmp $1/dev $1/proc $1/sys
 }
 
 if test -z $1 || ! test $1 -ge 0; then


### PR DESCRIPTION
For example, access to sysfs is needed to enable write to mmcblkXbootX
partition for preloader update:

echo 0 >  /sys/block/mmcblk0boot0/force_ro
dd if=preloader.bin bs=2048 of=/dev/mmcblk0boot0 seek=1
echo 1 >  /sys/block/mmcblk0boot0/force_ro