### PR TITLE
Set BuildArch to noarch

### DIFF
--- a/rpm/initrd-helpers.spec
+++ b/rpm/initrd-helpers.spec
@@ -5,6 +5,7 @@ Release:    1
 Group:      System/Boot
 License:    GPLv2
 Source0:    %{name}-%{version}.tar.gz
+BuildArch:  noarch
 
 Requires:  btrfs-progs
 Requires:  e2fsprogs


### PR DESCRIPTION
As there are no binaries compiled, use noarch as BuildArch. Without correct arch, Fedora starts complaining about non-existent debug symbols.
