### PR TITLE
find-mmc-bypartlabel: test for cases where the disk is on mmcblk1

### DIFF
--- a/find-mmc-bypartlabel
+++ b/find-mmc-bypartlabel
@@ -30,17 +30,17 @@ if [ ! -d /sys/class/block ]; then
 	exit 1
 fi
 
-while [ ! -d /sys/class/block/mmcblk0p* ] && [ ! -d /sys/class/block/sda ] ; do
-    echo "find-mmc-bypartlabel: Waiting for /sys/class/block/mmcblk0p*..." > /dev/kmsg
+while [ ! -d /sys/class/block/mmcblk[01]p* ] && [ ! -d /sys/class/block/sda ] ; do
+    echo "find-mmc-bypartlabel: Waiting for /sys/class/block/mmcblk[01]p*..." > /dev/kmsg
     i=$(( ${i:-0} + 1 ))
     sleep 0.5
     if [ $i -eq 10 ]; then
-        echo "find-mmc-bypartlabel: Error: timeout waiting for /sys/class/block/mmcblk0p*" > /dev/kmsg
+        echo "find-mmc-bypartlabel: Error: timeout waiting for /sys/class/block/mmcblk[01]p*" > /dev/kmsg
         exit 1
     fi
 done
 while [ ${i:-0} -le 50 ] ; do
-	for mmc_sysfs in /sys/class/block/mmcblk0p*/ /sys/class/block/sda*/; do
+	for mmc_sysfs in /sys/class/block/mmcblk[01]p*/ /sys/class/block/sda*/; do
 		if grep -q -w PARTNAME="$1" "$mmc_sysfs"/uevent 2> /dev/null; then
 			FIMAGE_DEV_NAME=$(echo $mmc_sysfs | cut -d "/" -f 5)
 			echo "/dev/$FIMAGE_DEV_NAME"


### PR DESCRIPTION
Few devices have internal storage labeled by kernel as mmcblk1. Adding it to search path may allow for SD card boot in some rare cases, however it should not happen if internal storage is functioning and has required partition as it is checked first.